### PR TITLE
Invoke commands with execute! on Windows using cmd.exe.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Simple Rust macro for building `std::process::Command` objects. U
 license = "MIT OR Apache-2.0"
 name = "commandspec"
 repository = "http://github.com/tcr/commandspec"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 ctrlc = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,19 @@ impl CommandSpec {
             binary = cd.join(&binary);
         }
 
+        // On windows, we run in cmd.exe by default. (This code is a naive way
+        // of accomplishing this and may contain errors.)
+        if cfg!(windows) {
+            let mut cmd = Command::new("cmd");
+            cmd.current_dir(cd);
+            let invoke_string = format!("{} {}", binary.as_path().to_string_lossy(), self.args.join(" "));
+            cmd.args(&["/C", &invoke_string]);
+            for (key, value) in &self.env {
+                cmd.env(key, value);
+            }
+            return cmd;
+        }
+
         let mut cmd = Command::new(binary);
         cmd.current_dir(cd);
         cmd.args(&self.args);


### PR DESCRIPTION
For the general cross-platform execute! case, it makes sense to reflect the user's current path on Windows, since this is similar to the behavior you would expect coming from a Linux background. Redirecting all commands to cmd.exe could be disabled via a feature; for example, with a default-features = false that disables cmd_indirection. That behavior would come in a later PR.