### PR TITLE
Port to anyhow/thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ repository = "http://github.com/tcr/commandspec"
 version = "0.12.2"
 
 [dependencies]
-failure = "0.1.1"
+thiserror = "1.0"
+anyhow = "1.0"
 shlex = "0.1.1"
 lazy_static = "1.0.0"
 log = "0.4.4"


### PR DESCRIPTION
The `failure` crate isn't being actively developed anymore; having
it as a dependency in the public API is a problem for consumers
that don't use it.

Instead, use anyhow/thiserror; in particular the public API for
errors now implements `std::error::Error`, which allows *consuming*
applications to e.g. directly use `?` rather than needing a
`.map_err(|e| e.compat())`.

As the docs for `thiserror` say:

> Thiserror deliberately does not appear in your public API. You get
> the same thing as if you had written an implementation of
> std::error::Error by hand, and switching from handwritten impls
> to thiserror or vice versa is not a breaking change.

And we're only using `anyhow` internally.